### PR TITLE
fix SteamUser returns null pointer

### DIFF
--- a/source/modules/voicechat.cpp
+++ b/source/modules/voicechat.cpp
@@ -4,9 +4,6 @@
 #include "Bootil/Bootil.h"
 #include <netmessages.h>
 #include "sourcesdk/baseclient.h"
-#include "steam/isteamuser.h"
-#include "steam/isteamclient.h"
-#include "steam/steamclientpublic.h"
 
 class CVoiceChatModule : public IModule
 {
@@ -153,30 +150,16 @@ LUA_FUNCTION_STATIC(VoiceData_GetData)
 	return 1;
 }
 
-static bool m_bSteamUserInit = false;
-ISteamUser* m_pSteamUser;
-
 LUA_FUNCTION_STATIC(VoiceData_GetUncompressedData)
 {
-	if (!m_bSteamUserInit) {
-		ISteamClient* m_pSteamClient = SteamGameServerClient();
-		if (!m_pSteamClient) {
-			LUA->ThrowError("Failed to get SteamClient!\n");
-		}
-		HSteamPipe hSteamPipe;
-		HSteamUser hSteamUser = m_pSteamClient->CreateLocalUser(&hSteamPipe, k_EAccountTypeIndividual);
-		m_pSteamUser = m_pSteamClient->GetISteamUser(hSteamUser, hSteamPipe, "SteamUser023");
-		m_bSteamUserInit = true;
-	}
-
 	VoiceData* pData = Get_VoiceData(1, true);
 
-	if (!m_pSteamUser)
+	if (!g_pSteamUser)
 		LUA->ThrowError("Failed to get SteamUser!\n");
 
 	uint32 pDecompressedLength;
 	char* pDecompressed = new char[20000];
-	m_pSteamUser->DecompressVoice(
+	g_pSteamUser->DecompressVoice(
 		pData->pData, pData->iLength,
 		pDecompressed, 20000,
 		&pDecompressedLength, 44100

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -9,6 +9,7 @@
 
 GarrysMod::Lua::IUpdatedLuaInterface* g_Lua;
 IVEngineServer* engine;
+ISteamUser* g_pSteamUser;
 CGlobalEntityList* Util::entitylist = NULL;
 CUserMessages* Util::pUserMessages;
 

--- a/source/util.h
+++ b/source/util.h
@@ -7,9 +7,12 @@
 #include "vprof.h"
 #define DEDICATED
 #include "vstdlib/jobthread.h"
+#include "steam/isteamuser.h"
 
 class IVEngineServer;
 extern IVEngineServer* engine;
+
+extern ISteamUser* g_pSteamUser;
 
 #define VPROF_BUDGETGROUP_HOLYLIB _T("HolyLib")
 


### PR DESCRIPTION
For some reason, when I tried to call the `VoiceData:GetUncompressedData` function in the `HolyLib:PreProcessVoiceChat` hook, I get the error: `Failed to get SteamUser!`. I don't know for what reason `SteamUser()` returns a null pointer, but this is the only solution I could find to fix this error. 
