### PR TITLE
Add HttpResponse:SetStatusCode to HttpServer

### DIFF
--- a/source/modules/httpserver.cpp
+++ b/source/modules/httpserver.cpp
@@ -1043,7 +1043,7 @@ void CHTTPServerModule::LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServe
 		Util::AddFunc(pLua, HttpResponse_SetContent, "SetContent");
 		Util::AddFunc(pLua, HttpResponse_SetHeader, "SetHeader");
 		Util::AddFunc(pLua, HttpResponse_SetRedirect, "SetRedirect");
-		Util::AddFunc(pLua, HttpResponse_SetStatusCode", "SetStatusCode");
+		Util::AddFunc(pLua, HttpResponse_SetStatusCode, "SetStatusCode");
 	pLua->Pop(1);
 
 	Lua::GetLuaData(pLua)->RegisterMetaTable(Lua::HttpRequest, pLua->CreateMetaTable("HttpRequest"));

--- a/source/modules/httpserver.cpp
+++ b/source/modules/httpserver.cpp
@@ -29,6 +29,7 @@ struct HttpResponse {
 	bool m_bSetRedirect = false;
 	bool m_bSetHeader = false;
 	int m_iRedirectCode = 302;
+	int m_iStatusCode = -1;
 	std::string m_strContent = "";
 	std::string m_strContentType = "text/plain";
 	std::string m_strRedirect = "";
@@ -41,6 +42,9 @@ struct HttpResponse {
 
 		if (m_bSetRedirect)
 			pResponse.set_redirect(m_strRedirect, m_iRedirectCode);
+
+		if (m_iStatusCode >= 100 && m_iStatusCode < 600)
+			pResponse.status = m_iStatusCode;
 
 		if (m_bSetHeader)
 			for (auto& [key, value] : m_pHeaders)
@@ -315,6 +319,14 @@ LUA_FUNCTION_STATIC(HttpResponse_SetRedirect)
 	pData->m_bSetRedirect = true;
 	pData->m_strRedirect = LUA->CheckString(2);
 	pData->m_iRedirectCode = (int)LUA->CheckNumberOpt(3, 302);
+
+	return 0;
+}
+
+LUA_FUNCTION_STATIC(HttpResponse_SetStatusCode)
+{
+	HttpResponse* pData = Get_HttpResponse(LUA, 1, true);
+	pData->m_iStatusCode = (int)LUA->CheckNumber(2);
 
 	return 0;
 }
@@ -1031,6 +1043,7 @@ void CHTTPServerModule::LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServe
 		Util::AddFunc(pLua, HttpResponse_SetContent, "SetContent");
 		Util::AddFunc(pLua, HttpResponse_SetHeader, "SetHeader");
 		Util::AddFunc(pLua, HttpResponse_SetRedirect, "SetRedirect");
+		Util::AddFunc(pLua, HttpResponse_SetStatusCode", "SetStatusCode");
 	pLua->Pop(1);
 
 	Lua::GetLuaData(pLua)->RegisterMetaTable(Lua::HttpRequest, pLua->CreateMetaTable("HttpRequest"));


### PR DESCRIPTION
Returning different status codes is an important part of any kind of REST API implementation, and web development in general. This is a simple addition with just a few lines, as HTTPLib will set the status code if it hasn't been changed from -1 to either OK_200 or PartialContent_206.

It also makes sure that the status code given is valid between 100 and 599.