### PR TITLE
Add HttpRequest.GetPathParam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Bootil/projects/release_x32_windows/
 Bootil/projects/release_x64_linux/
 Bootil/projects/release_x32_linux/
 **/.vs/
+**/.vscode/
 source/modules/32x/**
 source/modules/64x/**
 source/sourcesdk/tempshit

--- a/source/modules/httpserver.cpp
+++ b/source/modules/httpserver.cpp
@@ -394,6 +394,22 @@ LUA_FUNCTION_STATIC(HttpRequest_GetParam)
 	return 1;
 }
 
+LUA_FUNCTION_STATIC(HttpRequest_GetPathParam)
+{
+	HttpRequest* pData = Get_HttpRequest(LUA, 1, false);
+	const char* param = LUA->CheckString(2);
+
+	auto it = pData->m_pRequest.path_params.find(param);
+	if (it != pData->m_pRequest.path_params.end())
+	{
+		LUA->PushString(it->second.c_str());
+		return 1;
+	}
+
+	LUA->PushNil();
+	return 1;
+}
+
 LUA_FUNCTION_STATIC(HttpRequest_GetBody)
 {
 	HttpRequest* pData = Get_HttpRequest(LUA, 1, false);
@@ -1057,6 +1073,7 @@ void CHTTPServerModule::LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServe
 		Util::AddFunc(pLua, HttpRequest_HasParam, "HasParam");
 		Util::AddFunc(pLua, HttpRequest_GetHeader, "GetHeader");
 		Util::AddFunc(pLua, HttpRequest_GetParam, "GetParam");
+		Util::AddFunc(pLua, HttpRequest_GetPathParam, "GetPathParam");
 		Util::AddFunc(pLua, HttpRequest_GetBody, "GetBody");
 		Util::AddFunc(pLua, HttpRequest_GetRemoteAddr, "GetRemoteAddr");
 		Util::AddFunc(pLua, HttpRequest_GetRemotePort, "GetRemotePort");


### PR DESCRIPTION
This allows the capture of request path segments and their usage in request handlers.

Example:

```lua
local server = httpserver.Create()
server:Get("/user/:id", function(req, res)
    local userId = req:GetPathParam("id")
    if not userId then
        res:SetStatusCode(404)
        res:SetContent("No user specified")
        return
    end

    res:SetContent("UserID: "..userId)
end)

server:Start("0.0.0.0", 8080)
```