### PR TITLE
Autorefresh Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Wiki: https://holylib.raphaelit7.com/
 \- \- [CGameClient](https://github.com/RaphaelIT7/gmod-holylib#cgameclient)<br>
 \- \- [Singleplayer](https://github.com/RaphaelIT7/gmod-holylib#singleplayer)<br>
 \- \- [128+ Players](https://github.com/RaphaelIT7/gmod-holylib#128-players)<br>
+\- [autorefresh](#autorefresh)<br>
 
 [Unfinished Modules](https://github.com/RaphaelIT7/gmod-holylib#unfinished-modules)<br>
 \- [serverplugins](https://github.com/RaphaelIT7/gmod-holylib#serverplugins)<br>
@@ -4431,6 +4432,39 @@ end)
 
 hook.Add("HolyLib:OnPlayerChangedSlot", "Example", function(oldPlayerSlot, newPlayerSlot)
 	print("Client was moved from slot " .. oldPlayerSlot .. " to slot " .. newPlayerSlot)
+end)
+```
+
+## autorefresh
+The Autorefresh module currently provides functionalities regarding the in-built lua file autorefresh system.
+
+Supports: Linux32 | LINUX64
+
+### Functions
+None
+
+### Hooks
+#### bool HolyLib:BeforeLuaAutorefresh(string filePath, string filename)
+Called before a Lua file is being refreshed. If `true` is returned it will deny the refresh of the lua file.
+- string filePath — is the filePath provided relative to the garrysmod folder
+- string filename — is the filename without the extension
+```lua
+hook.Add("HolyLib:BeforeLuaAutorefresh", "ExampleBeforeRefresh", function(filePath, filename)
+    print("[BEFORE] FileChanged: " .. filePath .. filename)
+        
+    if filename == "bogos" then
+        print("Denying Refresh")
+    	return true -- prevent refresh
+    end
+end)
+```
+
+#### HolyLib:AfterLuaAutorefresh(string filePath, string filename)
+Called after a Lua file is refreshed. 
+Note that if a refresh is being denied by BeforeLuaAutorefresh, this hook won't be called.
+```lua
+hook.Add("HolyLib:AfterLuaAutorefresh", "ExampleAfterRefresh", function(filePath, filename)
+    print("[AFTER] FileChanged: " .. filePath .. filename)
 end)
 ```
 

--- a/source/modules/autorefresh.cpp
+++ b/source/modules/autorefresh.cpp
@@ -27,7 +27,7 @@ static bool hook_CAutoRefresh_HandleChange_Lua(const std::string* pfileRelPath, 
 	}
 
 	bool bDenyRefresh = false;
-	if (Lua::PushHook("HolyLib:GetLuaBeforeRefresh"))
+	if (Lua::PushHook("HolyLib:BeforeLuaAutorefresh"))
 	{
 		g_Lua->PushString(pfileRelPath->c_str());
 		g_Lua->PushString(pfileName->c_str());
@@ -48,7 +48,7 @@ static bool hook_CAutoRefresh_HandleChange_Lua(const std::string* pfileRelPath, 
 
 	bool original = detour_CAutoRefresh_HandleChange_Lua.GetTrampoline<Symbols::GarrysMod_AutoRefresh_HandleChange_Lua>()(pfileRelPath, pfileName, pfileExt);
 
-	if (Lua::PushHook("HolyLib:GetLuaAfterRefresh"))
+	if (Lua::PushHook("HolyLib:AfterLuaAutorefresh"))
 	{
 		g_Lua->PushString(pfileRelPath->c_str());
 		g_Lua->PushString(pfileName->c_str());

--- a/source/modules/autorefresh.cpp
+++ b/source/modules/autorefresh.cpp
@@ -12,7 +12,7 @@ public:
 	virtual void LuaShutdown(GarrysMod::Lua::ILuaInterface* pLua) OVERRIDE;
 	virtual void InitDetour(bool bPreServer) OVERRIDE;
 	virtual const char* Name() { return "autorefresh"; };
-	virtual int Compatibility() { return LINUX32; };
+	virtual int Compatibility() { return LINUX32 | LINUX64; };
 };
 
 CAutoRefreshModule g_pAutoRefreshModule;
@@ -68,7 +68,7 @@ void CAutoRefreshModule::LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServ
 	Util::FinishTable(pLua, "autorefresh");
 }
 
-void CAutoRefreshModule::LuaShutdown(GarrysMod::Lua::ILuaInterface *pLua)
+void CAutoRefreshModule::LuaShutdown(GarrysMod::Lua::ILuaInterface* pLua)
 {
 	Util::NukeTable(pLua, "autorefresh");
 }

--- a/source/modules/autorefresh.cpp
+++ b/source/modules/autorefresh.cpp
@@ -1,0 +1,88 @@
+#include "module.h"
+#include "LuaInterface.h"
+#include "lua.h"
+#include "detours.h"
+
+#include "tier0/memdbgon.h"
+
+class CAutoRefreshModule : public IModule
+{
+public:
+	virtual void LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServerInit) OVERRIDE;
+	virtual void LuaShutdown(GarrysMod::Lua::ILuaInterface* pLua) OVERRIDE;
+	virtual void InitDetour(bool bPreServer) OVERRIDE;
+	virtual const char* Name() { return "autorefresh"; };
+	virtual int Compatibility() { return LINUX32; };
+};
+
+CAutoRefreshModule g_pAutoRefreshModule;
+IModule* pAutoRefreshModule = &g_pAutoRefreshModule;
+
+static Detouring::Hook detour_CAutoRefresh_HandleChange_Lua;
+static bool hook_CAutoRefresh_HandleChange_Lua(const std::string* pfileRelPath, const std::string* pfileName, const std::string* pfileExt)
+{
+	if (!g_Lua)
+	{
+		return true;
+	}
+
+	bool bDenyRefresh = false;
+	if (Lua::PushHook("HolyLib:GetLuaBeforeRefresh"))
+	{
+		g_Lua->PushString(pfileRelPath->c_str());
+		g_Lua->PushString(pfileName->c_str());
+
+		if (g_Lua->CallFunctionProtected(3, 1, true))
+		{
+			if (g_Lua->IsType(-1, GarrysMod::Lua::Type::BOOL))
+			{
+				bDenyRefresh = g_Lua->GetBool(-1);
+			}
+		}
+		g_Lua->Pop(1);
+	}
+
+	if (bDenyRefresh) {
+		return true;
+	}
+
+	bool original = detour_CAutoRefresh_HandleChange_Lua.GetTrampoline<Symbols::GarrysMod_AutoRefresh_HandleChange_Lua>()(pfileRelPath, pfileName, pfileExt);
+
+	if (Lua::PushHook("HolyLib:GetLuaAfterRefresh"))
+	{
+		g_Lua->PushString(pfileRelPath->c_str());
+		g_Lua->PushString(pfileName->c_str());
+
+		g_Lua->CallFunctionProtected(3, 0, true);
+	}
+
+	return original;
+};
+
+void CAutoRefreshModule::LuaInit(GarrysMod::Lua::ILuaInterface* pLua, bool bServerInit)
+{
+	if (bServerInit)
+		return;
+
+	Util::StartTable(pLua);
+	Util::FinishTable(pLua, "autorefresh");
+}
+
+void CAutoRefreshModule::LuaShutdown(GarrysMod::Lua::ILuaInterface *pLua)
+{
+	Util::NukeTable(pLua, "autorefresh");
+}
+
+void CAutoRefreshModule::InitDetour(bool bPreServer)
+{
+	if (bPreServer)
+		return;
+
+	SourceSDK::FactoryLoader server_loader("server");
+
+	Detour::Create(
+		&detour_CAutoRefresh_HandleChange_Lua, "CAutoRefresh_HandleChange_Lua",
+		server_loader.GetModule(), Symbols::GarrysMod_AutoRefresh_HandleChange_LuaSym,
+		(void*)hook_CAutoRefresh_HandleChange_Lua, m_pID
+	);
+}

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -942,4 +942,11 @@ namespace Symbols
 	const std::vector<Symbol> UTIL_TraceEntity2Sym = {
 		Symbol::FromName("_Z16UTIL_TraceEntityP11CBaseEntityRK6VectorS3_jP10CGameTrace"),
 	};
+
+	//---------------------------------------------------------------------------------
+	// Purpose: AutoRefresh Symbols
+	//---------------------------------------------------------------------------------
+	const std::vector<Symbol> GarrysMod_AutoRefresh_HandleChange_LuaSym = {
+		Symbol::FromName("_ZN9GarrysMod11AutoRefresh16HandleChange_LuaERKSsS2_S2_"),
+	};
 }

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -948,5 +948,6 @@ namespace Symbols
 	//---------------------------------------------------------------------------------
 	const std::vector<Symbol> GarrysMod_AutoRefresh_HandleChange_LuaSym = {
 		Symbol::FromName("_ZN9GarrysMod11AutoRefresh16HandleChange_LuaERKSsS2_S2_"),
+		Symbol::FromSignature("\x55\x48\x89\xE5\x41\x57\x41\x56\x49\x89\xD6\x41\x55\x49\x89\xFD\x48\x89\xD7\x41\x54"),
 	};
 }

--- a/source/symbols.h
+++ b/source/symbols.h
@@ -687,4 +687,10 @@ namespace Symbols
 
 	typedef void (*UTIL_TraceEntity2)(CBaseEntity *pEntity, const Vector &vecAbsStart, const Vector &vecAbsEnd, unsigned int mask, trace_t *ptr);
 	extern const std::vector<Symbol> UTIL_TraceEntity2Sym;
+
+	//---------------------------------------------------------------------------------
+	// Purpose: AutoRefresh Symbols
+	//---------------------------------------------------------------------------------
+	typedef bool (*GarrysMod_AutoRefresh_HandleChange_Lua)(const std::string* fileRelPath, const std::string* fileName, const std::string* fileExt);
+	extern const std::vector<Symbol> GarrysMod_AutoRefresh_HandleChange_LuaSym;
 }


### PR DESCRIPTION
#36 as per issue
This PR introduces the AutoRefresh module, enabling Lua file change detection and providing two new hooks.
- `BeforeLuaAutorefresh` – Triggered before a lua file is autorefreshed. Returning true inside of the hook will prevent the refresh.
- `AfterLuaAutorefresh` – Triggered after a lua file has been auto-refreshed.

Currently only for linux32 and linux64