### PR TITLE
Networking Module Fixes

### DIFF
--- a/source/modules/networking.cpp
+++ b/source/modules/networking.cpp
@@ -1823,7 +1823,6 @@ bool New_CServerGameEnts_CheckTransmit(IServerGameEnts* gameents, CCheckTransmit
 
 	const int clientEntIndex = pInfo->m_pClientEnt->m_EdictIndex;
 	static CBitVec<MAX_EDICTS> pClientCache; // Temporary cache used when we are calculating the transmit to the current pRecipientPlayer
-	pClientCache.ClearAll(); // Clear stale data from previous calls when previously using fast path
 	const bool bForceTransmit = sv_force_transmit_ents->GetBool();
 	bool bWasTransmitToPlayer = false;
 #if NETWORKING_USE_ENTITYCACHE
@@ -2039,7 +2038,7 @@ bool New_CServerGameEnts_CheckTransmit(IServerGameEnts* gameents, CCheckTransmit
 
 	// HLTV has different networking! Some things might transmit when for normal players they wouldn't!
 	// ObserverMode also influences how things are networked!
-	if (bFastPath && !bIsHLTV && !(pRecipientPlayer->GetObserverMode() == OBS_MODE_IN_EYE && pRecipientPlayer->GetObserverTarget()) && bWasTransmitToPlayer)
+	if (bFastPath && !bIsHLTV && !(pRecipientPlayer->GetObserverMode() == OBS_MODE_IN_EYE && pRecipientPlayer->GetObserverTarget()))
 	{
 		PlayerTransmitTickCache& nTransmitCache = g_pPlayerTransmitTickCache[clientIndex];
 		// Remove player's viewmodels from the cache since thoes are supposed to only be networked to the recipient player


### PR DESCRIPTION
Fixed an issue where spectating another player networked the recipients viewmodels instead of the spectated players
Fixed an issue where weapon transmission cache was not working due to an incorrect variable
~~Fixed an issue where `pClientCache` could become corrupted due to stale data from an early fast path return which likely caused players and entities to disappear, as reported in #112.~~