### PR TITLE
Fix win x86 way of getting IServer

### DIFF
--- a/source/util.cpp
+++ b/source/util.cpp
@@ -799,11 +799,7 @@ void Util::AddDetour()
 
 	// Why must getting IServer be an inconsistent hell :sob:
 #if SYSTEM_WINDOWS
-#if ARCHITECTURE_X86_64
 	server = Detour::ResolveSymbolNoDereference<IServer>( engine_loader, Symbol::FromName( "?sv@@3VCGameServer@@A" ) );
-#else
-	server = *(IServer**)InterfacePointers::Server();
-#endif
 #else
 	server = InterfacePointers::Server();
 #endif


### PR DESCRIPTION
With the recent changes i guess the way of getting IServer can be the same as x64 and it seem to work pretty well, i tried on both Dedicated and Client win x86 and both worked well 