### PR TITLE
Fix `autorefresh` Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5171,12 +5171,12 @@ Useful when you added/removed folders.
 #### bool HolyLib:PreLuaAutoRefresh(string filePath, string fileName)
 Called before a Lua file is being refreshed. If `true` is returned it will deny the refresh of the lua file.
 - string filePath — is the filePath provided relative to the garrysmod folder
-- string filename — is the filename without the extension
+- string fileName — is the filename without the extension
 ```lua
 hook.Add("HolyLib:PreLuaAutoRefresh", "ExamplePreAutoRefresh", function(filePath, fileName)
-    print("[BEFORE] FileChanged: " .. filePath .. filename)
+    print("[BEFORE] FileChanged: " .. filePath .. fileName)
 
-    if filename == "bogus" then
+    if fileName == "bogus" then
         print("Denying Refresh")
     	return true -- prevent refresh
     end
@@ -5188,7 +5188,7 @@ Called after a Lua file is refreshed.
 Note that if a refresh is being denied by PreLuaAutorefresh or DenyLuaAutoRefresh, this hook won't be called.
 ```lua
 hook.Add("HolyLib:PostLuaAutoRefresh", "ExamplePostAutoRefresh", function(filePath, fileName)
-    print("[AFTER] FileChanged: " .. filePath .. filename)
+    print("[AFTER] FileChanged: " .. filePath .. fileName)
 end)
 ```
 

--- a/source/modules/autorefresh.cpp
+++ b/source/modules/autorefresh.cpp
@@ -3,7 +3,7 @@
 #include "lua.h"
 #include "detours.h"
 
-#include <unordered_map>
+#include <unordered_set>
 
 #include "tier0/memdbgon.h"
 
@@ -41,6 +41,7 @@ struct FileTimeJob {
 		strFileName = fileName;
 
 		nFileTime = g_pFullFileSystem->GetFileTime(strFileName.c_str(), "MOD");
+		bChanged = false;
 	}
 
 	Bootil::BString strFileName;
@@ -56,7 +57,7 @@ static bool AddFileToAutoRefresh(Bootil::BString pFilename)
 			return false;
 	}
 
-	auto newEntry = pFileTimestamps.emplace_back();
+	auto& newEntry = pFileTimestamps.emplace_back();
 	newEntry.Init(pFilename);
 	return true;
 }
@@ -79,7 +80,9 @@ static bool RemoveFileFromAutoRefresh(Bootil::BString pFilename)
 
 static void CheckFileTime(FileTimeJob* pJob)
 {
-	pJob->nFileTime = g_pFullFileSystem->GetFileTime(pJob->strFileName.c_str(), "MOD");
+	long nFileTime = g_pFullFileSystem->GetFileTime(pJob->strFileName.c_str(), "MOD");
+	pJob->bChanged = nFileTime != pJob->nFileTime;
+	pJob->nFileTime = nFileTime;
 }
 
 static Bootil::File::ChangeMonitor* g_pChangeMonitor = nullptr;
@@ -127,7 +130,8 @@ static void hook_Bootil_File_ChangeMonitor_CheckForChanges(Bootil::File::ChangeM
 			{
 				pFileJob.bChanged = false;
 				CheckFileTime(&pFileJob);
-				pMonitor->NoteFileChanged(pFileJob.strFileName);
+				if (pFileJob.bChanged)
+					pMonitor->NoteFileChanged(pFileJob.strFileName);
 				pFileJob.bChanged = false;
 			}
 		}
@@ -159,7 +163,7 @@ static bool hook_GarrysMod_AutoRefresh_HandleChange_Lua(const std::string* pfile
 		}
 	}
 
-	if (pBlacklistedFiles.find(*const_cast<Bootil::BString*>(pfileRelPath)) != pBlacklistedFiles.end())
+	if (pBlacklistedFiles.find(*pfileRelPath) != pBlacklistedFiles.end())
 	{
 		bDenyRefresh = true;
 	}

--- a/source/symbols.cpp
+++ b/source/symbols.cpp
@@ -1097,7 +1097,7 @@ namespace Symbols
 	};
 
 	const std::vector<Symbol> Bootil_File_ChangeMonitor_CheckForChangesSym = {
-		Symbol::FromName("_ZN6Bootil4File13ChangeMonitor10HasChangesEv"),
+		Symbol::FromName("_ZN6Bootil4File13ChangeMonitor15CheckForChangesEv"),
 	};
 
 	const std::vector<Symbol> Bootil_File_ChangeMonitor_HasChangesSym = {


### PR DESCRIPTION
- Fixed manually watched autorefresh files being incorrectly detected as changed on every check  
- Fixed autorefresh timestamp tracking failing to update stored file entries  
- Removed an unnecessary `const_cast` from the autorefresh blacklist lookup  
- Updated autorefresh include to use `unordered_set` for blacklist storage  
- Fixed `autorefresh` documentation examples  
- Fixed `Bootil_File_ChangeMonitor_CheckForChangesSym`