### PR TITLE
Fix `gmoddatapack` Module

### DIFF
--- a/source/modules/gmoddatapack.cpp
+++ b/source/modules/gmoddatapack.cpp
@@ -803,11 +803,11 @@ public:
 			removeComments = false;
 		}
 
-		bool hasSourceContent = false;
 		std::string sourceContent = "";
 		std::string content = "";
 		Bootil::AutoBuffer compressed;
 		std::shared_mutex mutex; // Per entry instead of a global mutex to avoid blocking the main thread for other entries while compressing
+		bool hasSourceContent = false;
 		bool processed = false;
 		bool removeServerCode = false;
 		bool removeComments = false;
@@ -849,6 +849,8 @@ public:
 		pEntry.hasSourceContent = true;
 		pEntry.sourceContent = content;
 		pEntry.content = content;
+		pEntry.removeServerCode = bRemoveServerCode;
+		pEntry.removeComments = bRemoveComments;
 		pEntry.processed = false;
 		if (ThreadInMainThread())
 			ProcessContent(&pEntry, fileID);
@@ -861,7 +863,7 @@ public:
 	}
 
 	// We only strip it, if it's valid lua (yes my token stuff is highly sensitive!)
-	std::string StripContent(std::string content, bool* bError, int fileID)
+	std::string StripContent(std::string content, bool* bError, int fileID, bool bRemoveServerCode, bool bRemoveComments)
 	{
 		*bError = false;
 		lua_State* L = luaL_newstate();
@@ -893,13 +895,13 @@ public:
 			}
 		}
 
-		return ProcessTokens(tokens, gmoddatapack_removeserverif.GetBool(), gmoddatapack_removecomments.GetBool());
+		return ProcessTokens(tokens, bRemoveServerCode, bRemoveComments);
 	}
 
 	void ProcessContent(LuaPackEntry* pEntry, int fileID)
 	{
 		bool bError;
-		std::string strippedContent = StripContent(pEntry->content, &bError, fileID);
+		std::string strippedContent = StripContent(pEntry->content, &bError, fileID, pEntry->removeServerCode, pEntry->removeComments);
 		if (bError)
 		{
 			Warning(PROJECT_NAME " - gmoddatapack: Failed to strip fileID \"%i\" due to lua errors! (%s)", fileID, strippedContent.c_str());
@@ -907,8 +909,6 @@ public:
 			pEntry->content = strippedContent;
 		}
 		pEntry->processed = true;
-		pEntry->removeServerCode = gmoddatapack_removeserverif.GetBool();
-		pEntry->removeComments = gmoddatapack_removecomments.GetBool();
 
 		if (ThreadInMainThread()) // SetStringUserData is NOT thread safe!
 		{

--- a/source/modules/gmoddatapack.cpp
+++ b/source/modules/gmoddatapack.cpp
@@ -852,8 +852,6 @@ public:
 		pEntry.removeServerCode = bRemoveServerCode;
 		pEntry.removeComments = bRemoveComments;
 		pEntry.processed = false;
-		if (ThreadInMainThread())
-			ProcessContent(&pEntry, fileID);
 
 		if (g_pGModDataPackModule.InDebug())
 			Msg(PROJECT_NAME " - gmoddatapack: Added fileID %i into compression queue!\n", fileID);

--- a/source/modules/gmoddatapack.cpp
+++ b/source/modules/gmoddatapack.cpp
@@ -794,15 +794,23 @@ public:
 
 		inline void Clear()
 		{
+			hasSourceContent = false;
+			sourceContent = "";
 			content = "";
 			compressed.Clear();
 			processed = false;
+			removeServerCode = false;
+			removeComments = false;
 		}
 
+		bool hasSourceContent = false;
+		std::string sourceContent = "";
 		std::string content = "";
 		Bootil::AutoBuffer compressed;
 		std::shared_mutex mutex; // Per entry instead of a global mutex to avoid blocking the main thread for other entries while compressing
 		bool processed = false;
+		bool removeServerCode = false;
+		bool removeComments = false;
 	};
 
 	void Initialize();
@@ -825,11 +833,25 @@ public:
 
 		LuaPackEntry& pEntry = m_pLuaFileCache[fileID];
 		std::lock_guard<std::shared_mutex> lock(pEntry.mutex);
-		if (pEntry.content == content) // Nothing changed
+		bool bRemoveServerCode = gmoddatapack_removeserverif.GetBool();
+		bool bRemoveComments = gmoddatapack_removecomments.GetBool();
+		bool bSameSource = pEntry.hasSourceContent && pEntry.sourceContent == content;
+		bool bSameProcessConfig = pEntry.removeServerCode == bRemoveServerCode && pEntry.removeComments == bRemoveComments;
+		if (bSameSource && pEntry.IsContentReady() && bSameProcessConfig) // Nothing changed
+		{
+			std::vector<unsigned char> pHash = HashString(pEntry.content.c_str(), pEntry.content.length() + 1);
+			g_pDataPack->m_pClientLuaFiles->SetStringUserData(fileID, pHash.size(), pHash.data());
+
 			return;
+		}
 
 		pEntry.compressed.Clear();
+		pEntry.hasSourceContent = true;
+		pEntry.sourceContent = content;
 		pEntry.content = content;
+		pEntry.processed = false;
+		if (ThreadInMainThread())
+			ProcessContent(&pEntry, fileID);
 
 		if (g_pGModDataPackModule.InDebug())
 			Msg(PROJECT_NAME " - gmoddatapack: Added fileID %i into compression queue!\n", fileID);
@@ -885,6 +907,8 @@ public:
 			pEntry->content = strippedContent;
 		}
 		pEntry->processed = true;
+		pEntry->removeServerCode = gmoddatapack_removeserverif.GetBool();
+		pEntry->removeComments = gmoddatapack_removecomments.GetBool();
 
 		if (ThreadInMainThread()) // SetStringUserData is NOT thread safe!
 		{


### PR DESCRIPTION
- Updated `gmoddatapack` to compare processed Lua content instead of raw file contents  
- Fixed cache invalidation when changing the `removeserverif` or `removecomments` settings  
- Fixed client Lua hash updates so they now reflect processed content even when files themselves are unchanged  
~~- Lua datapack content is now processed immediately on the main thread whenever files are added or updated, fixing the same issue I experienced with the addon used in [gmod-holylib issue #162](https://github.com/RaphaelIT7/gmod-holylib/issues/162)~~