### PR TITLE
steamworks: Fix segfault by fetching SteamGameServer() fresh per call

### DIFF
--- a/source/lua.h
+++ b/source/lua.h
@@ -4,6 +4,7 @@
 #include "bitvec.h"
 #include <atomic>
 #include <mutex>
+#include <condition_variable>
 #include "../luajit/src/lua.h"
 #if !defined(DISABLE_GMODJIT)
 #include "../gmod-luajit/luajit.h"

--- a/source/modules/steamworks.cpp
+++ b/source/modules/steamworks.cpp
@@ -81,7 +81,9 @@ static bool hook_CSteam3Server_NotifyClientConnect(CSteam3Server* srv, CBaseClie
 		if (!bRet)
 		{
 			// Try it again so that we get the reason why it failed.
-			status = SteamGameServer()->BeginAuthSession( pvCookie, ucbCookie, steamID );
+			ISteamGameServer* pGameServer = SteamGameServer();
+			if (pGameServer)
+				status = pGameServer->BeginAuthSession( pvCookie, ucbCookie, steamID );
 		}
 		g_Lua->PushNumber(status);
 

--- a/source/modules/steamworks.cpp
+++ b/source/modules/steamworks.cpp
@@ -32,7 +32,6 @@ static Symbols::Steam3ServerT func_Steam3Server;
 static Symbols::CSteam3Server_Shutdown func_CSteam3Server_Shutdown;
 static Symbols::CSteam3Server_Activate func_CSteam3Server_Activate;
 static Symbols::SV_InitGameServerSteam func_SV_InitGameServerSteam;
-static ISteamGameServer* g_pSteamGameServer = nullptr;
 
 static Detouring::Hook detour_CSteam3Server_OnLoggedOff;
 static void hook_CSteam3Server_OnLoggedOff(CSteam3Server* srv, SteamServersDisconnected_t* info)
@@ -167,21 +166,18 @@ LUA_FUNCTION_STATIC(steamworks_Activate)
 	return 1;
 }
 
+// Fetch SteamGameServer() fresh per call; a cached pointer goes stale across SteamGameServer_Init/Shutdown cycles
 LUA_FUNCTION_STATIC(steamworks_IsSecure)
 {
-	if (!g_pSteamGameServer)
-		LUA->ThrowError("Failed to get SteamGameServer!");
-
-	LUA->PushBool(g_pSteamGameServer->BSecure());
+	ISteamGameServer* pGameServer = SteamGameServer();
+	LUA->PushBool(pGameServer && pGameServer->BSecure());
 	return 1;
 }
 
 LUA_FUNCTION_STATIC(steamworks_IsConnected)
 {
-	if (!g_pSteamGameServer)
-		LUA->ThrowError("Failed to get SteamGameServer!");
-
-	LUA->PushBool(g_pSteamGameServer->BLoggedOn());
+	ISteamGameServer* pGameServer = SteamGameServer();
+	LUA->PushBool(pGameServer && pGameServer->BLoggedOn());
 	return 1;
 }
 
@@ -219,10 +215,11 @@ LUA_FUNCTION_STATIC(steamworks_ForceAuthenticate)
 
 LUA_FUNCTION_STATIC(steamworks_GetGameServerSteamID)
 {
-	if (!g_pSteamGameServer)
+	ISteamGameServer* pGameServer = SteamGameServer();
+	if (!pGameServer)
 		LUA->ThrowError("Failed to get SteamGameServer!");
 
-	std::string steamID64 = std::to_string( g_pSteamGameServer->GetSteamID().ConvertToUint64() );
+	std::string steamID64 = std::to_string( pGameServer->GetSteamID().ConvertToUint64() );
 	LUA->PushString( steamID64.c_str() );
 	return 1;
 }
@@ -316,8 +313,6 @@ void CSteamWorksModule::InitDetour(bool bPreServer)
 {
 	if ( bPreServer )
 		return;
-
-	g_pSteamGameServer = SteamGameServer();
 
 	DETOUR_PREPARE_THISCALL();
 	SourceSDK::ModuleLoader engine_loader("engine");


### PR DESCRIPTION
Since 59993401, `steamworks.IsConnected()` segfaults on x86-64. My gamemode polls it on a 30s timer, so the server crash-loops shortly after boot.

`g_pSteamGameServer` is cached in `InitDetour`, before the server logs onto Steam. The gameserver API gets re-initialized between then and logon, so the cached pointer is dangling by the time anything calls through it. The SDK accessor already handles this (`SteamInternal_ContextInit` re-resolves across init cycles, so per-call fetches are basically free), and a cached pointer also dies on *any* platform if `steamworks.Shutdown()`/`Activate()` re-init the API.

Fix: fetch fresh + null-guard in each Lua function, same pattern as `CSteam3Server::BLoggedOn()` in the vendored sv_steamauth.h. `IsConnected`/`IsSecure` now intentionally return `false` instead of throwing when there's no gameserver; `GetGameServerSteamID` keeps the throw. Also applied the same guard to the `BeginAuthSession` retry in `NotifyClientConnect`.

Last commit adds a missing `#include <condition_variable>` to lua.h (`LuaMutex` uses it; GCC 16's `<mutex>` no longer pulls it in transitively).

Tested on Linux x86-64 srcds (build 260611): the steamworks functions return correct values and the crash loop is gone.

Related: #4