### PR TITLE
Fix runtime guard paths

### DIFF
--- a/gluatests/lua/gmod_tests/sh_init.lua
+++ b/gluatests/lua/gmod_tests/sh_init.lua
@@ -21,7 +21,8 @@ FCVAR_AVAILABLE1 = bit.lshift( 1, 26 )
 FCVAR_AVAILABLE2 = bit.lshift( 1, 27 )
 
 function HolyLib_IsModuleEnabled(name)
-    return GetConVar("holylib_enable_" .. name):GetBool()
+    local convar = GetConVar("holylib_enable_" .. string.lower(name))
+    return convar and convar:GetBool() or false
 end
 
 require("reqwest")

--- a/gluatests/lua/tests/modules/stringtable/AllowCreation.lua
+++ b/gluatests/lua/tests/modules/stringtable/AllowCreation.lua
@@ -20,7 +20,7 @@ return {
             when = HolyLib_IsModuleEnabled("stringtable"),
             func = function()
                 stringtable.AllowCreation( true )
-                local table = stringtable.CreateStringTable( GetTestStringTableName() 4096, 0, 0 )
+                local table = stringtable.CreateStringTable( GetTestStringTableName(), 4096, 0, 0 )
                 stringtable.AllowCreation( false )
 
                 expect( table:IsValid() ).to.beTrue()

--- a/gluatests/lua/tests/modules/stringtable/RemoveTable.lua
+++ b/gluatests/lua/tests/modules/stringtable/RemoveTable.lua
@@ -35,7 +35,7 @@ return {
             when = HolyLib_IsModuleEnabled("stringtable"),
             func = function()
                 stringtable.AllowCreation( true )
-                local table = stringtable.CreateStringTable( GetTestStringTableName() 4096, 0, 0 )
+                local table = stringtable.CreateStringTable( GetTestStringTableName(), 4096, 0, 0 )
                 stringtable.AllowCreation( false )
 
                 expect( table:IsValid() ).to.beTrue()

--- a/luajit/src/lib_jit.c
+++ b/luajit/src/lib_jit.c
@@ -91,13 +91,13 @@ LJLIB_CF(jit_flush)
 LJLIB_CF(jit_enablecheckhook)
 {
   L2J(L)->additionalflags |= JIT_AF_CHECKHOOK;
-  setjitmode(L, LUAJIT_MODE_FLUSH);
+  return setjitmode(L, LUAJIT_MODE_FLUSH);
 }
 
 LJLIB_CF(jit_disablecheckhook)
 {
   L2J(L)->additionalflags &= ~JIT_AF_CHECKHOOK;
-  setjitmode(L, LUAJIT_MODE_FLUSH);
+  return setjitmode(L, LUAJIT_MODE_FLUSH);
 }
 
 #if LJ_HASJIT

--- a/luajit/src/lj_ir.h
+++ b/luajit/src/lj_ir.h
@@ -213,8 +213,8 @@ IRFPMDEF(FPMENUM)
   _(UDATA_VALUE, sizeof(GCudata)) \
   _(GMOD_UDATA_TYPE, offsetof(GMODudata, type)) \
   _(GMOD_UDATA_DATA, offsetof(GMODudata, data)) \
-  _(GMOD_UDATA_TYPE_DIRECT, (sizeof(GCudata) + offsetof(GMODudata, data))) \
-  _(GMOD_UDATA_DATA_DIRECT, (sizeof(GCudata) + offsetof(GMODudata, type))) \
+  _(GMOD_UDATA_TYPE_DIRECT, (sizeof(GCudata) + offsetof(GMODudata, type))) \
+  _(GMOD_UDATA_DATA_DIRECT, (sizeof(GCudata) + offsetof(GMODudata, data))) \
   _(LSTR_DATA, offsetof(lua_String, data)) \
   _(LSTR_LEN, offsetof(lua_String, length)) \
   _(SBUF_W,	sizeof(GCudata) + offsetof(SBufExt, w)) \

--- a/source/lua.h
+++ b/source/lua.h
@@ -475,7 +475,7 @@ namespace Lua
 				{
 					const char* pError = pLua->GetString(-1);
 					pLua->Pop(1);
-					pLua->ErrorFromLua(pError);
+					pLua->ErrorFromLua("%s", pError ? pError : "<lua error>");
 				} else {
 					pLua->Pop(1);
 				}

--- a/source/lua/CLuaInterface.cpp
+++ b/source/lua/CLuaInterface.cpp
@@ -271,7 +271,7 @@ CLuaInterface::~CLuaInterface()
 	}
 
 	// This is just for safety to ensure no memory leaks.
-	for (int i=0; i<255; ++i) {
+	for (int i=0; i<MAX_METATABLES; ++i) {
 		if (m_pMetaTables[i])
 		{
 			DestroyObject(m_pMetaTables[i]);
@@ -620,7 +620,7 @@ void CLuaInterface::CreateMetaTableType(const char* strName, int iType)
 {
 	LuaDebugPrint(1, "CLuaInterface::CreateMetaTableType(%s, %i)\n", strName, iType);
 	int ret = luaL_newmetatable_type(state, strName, iType);
-	if (ret && iType >= 0 && iType < (int)(sizeof(m_pMetaTables) / sizeof(m_pMetaTables[0])))
+	if (ret && iType >= 0 && iType < MAX_METATABLES)
 	{
 		GarrysMod::Lua::ILuaObject* pObject = m_pMetaTables[iType];
 		if (!pObject)
@@ -745,7 +745,7 @@ int CLuaInterface::CreateMetaTable(const char* strName) // Return value is proba
 bool CLuaInterface::PushMetaTable(int iType)
 {
 	LuaDebugPrint(2, "CLuaInterface::PushMetaTable %i\n", iType);
-	if (iType >= 0 && iType < (int)(sizeof(m_pMetaTables) / sizeof(m_pMetaTables[0])))
+	if (iType >= 0 && iType < MAX_METATABLES)
 	{
 		GarrysMod::Lua::ILuaObject* pMetaObject = m_pMetaTables[iType];
 		if (pMetaObject)
@@ -803,7 +803,7 @@ bool CLuaInterface::Init( GarrysMod::Lua::ILuaGameCallback* callback, bool bIsSe
 	}
 
 	m_iMetaTableIDCounter = GarrysMod::Lua::Type::Type_Count;
-	for (int i=0; i<=254; ++i)
+	for (int i=0; i<MAX_METATABLES; ++i)
 		m_pMetaTables[i] = nullptr;
 
 	m_iCurrentTempObject = 0;
@@ -905,7 +905,7 @@ void CLuaInterface::Shutdown()
 	lua_close(state);
 	state = nullptr;
 
-	for (int i=0; i<255; ++i) {
+	for (int i=0; i<MAX_METATABLES; ++i) {
 		if (m_pMetaTables[i])
 		{
 			DestroyObject(m_pMetaTables[i]);

--- a/source/lua/CLuaInterface.cpp
+++ b/source/lua/CLuaInterface.cpp
@@ -610,7 +610,7 @@ const char* CLuaInterface::GetTypeName(int iType)
 		return "none";
 
 	constexpr int typeCount = sizeof(GarrysMod::Lua::Type::Name) / sizeof(const char*);
-	if (iType <= typeCount)
+	if (iType < typeCount)
 		return GarrysMod::Lua::Type::Name[iType];
 
 	return "unknown";
@@ -620,7 +620,7 @@ void CLuaInterface::CreateMetaTableType(const char* strName, int iType)
 {
 	LuaDebugPrint(1, "CLuaInterface::CreateMetaTableType(%s, %i)\n", strName, iType);
 	int ret = luaL_newmetatable_type(state, strName, iType);
-	if (ret && iType <= 254)
+	if (ret && iType >= 0 && iType < (int)(sizeof(m_pMetaTables) / sizeof(m_pMetaTables[0])))
 	{
 		GarrysMod::Lua::ILuaObject* pObject = m_pMetaTables[iType];
 		if (!pObject)
@@ -745,7 +745,7 @@ int CLuaInterface::CreateMetaTable(const char* strName) // Return value is proba
 bool CLuaInterface::PushMetaTable(int iType)
 {
 	LuaDebugPrint(2, "CLuaInterface::PushMetaTable %i\n", iType);
-	if (iType <= 254)
+	if (iType >= 0 && iType < (int)(sizeof(m_pMetaTables) / sizeof(m_pMetaTables[0])))
 	{
 		GarrysMod::Lua::ILuaObject* pMetaObject = m_pMetaTables[iType];
 		if (pMetaObject)
@@ -1539,20 +1539,24 @@ void CLuaInterface::ErrorNoHalt( const char* fmt, ... )
 	GarrysMod::Lua::ILuaGameCallback::CLuaError* error = ReadStackIntoError(state);
 
 	va_list args;
+	va_list argsCopy;
 	va_start(args, fmt);
+	va_copy(argsCopy, args);
 
 	int size = vsnprintf(nullptr, 0, fmt, args);
 	if (size < 0) {
 		va_end(args);
+		va_end(argsCopy);
 		return;
 	}
 
 	char* buffer = new char[size + 1];
-	vsnprintf(buffer, size + 1, fmt, args);
+	vsnprintf(buffer, size + 1, fmt, argsCopy);
 	buffer[size] = '\0';
 
 	error->message = buffer;
 	va_end(args);
+	va_end(argsCopy);
 
 	m_pGameCallback->LuaError(error);
 
@@ -1705,20 +1709,24 @@ void CLuaInterface::ErrorFromLua(const char *fmt, ...)
 	GarrysMod::Lua::ILuaGameCallback::CLuaError* error = ReadStackIntoError(state);
 
 	va_list args;
+	va_list argsCopy;
 	va_start(args, fmt);
+	va_copy(argsCopy, args);
 
 	int size = vsnprintf(nullptr, 0, fmt, args);
 	if (size < 0) {
 		va_end(args);
+		va_end(argsCopy);
 		return;
 	}
 
 	char* buffer = new char[size + 1];
-	vsnprintf(buffer, size + 1, fmt, args);
+	vsnprintf(buffer, size + 1, fmt, argsCopy);
 	buffer[size] = '\0';
 
 	error->message = buffer;
 	va_end(args);
+	va_end(argsCopy);
 	
 	/* NOTE: This is already done in ReadStackIntoError
 	

--- a/source/lua/CLuaInterface.h
+++ b/source/lua/CLuaInterface.h
@@ -9,6 +9,7 @@
 #include "tier1/utlstack.h"
 #include <atomic>
 
+#undef max
 #define GMOD
 
 #ifdef BUILD_GMOD
@@ -200,7 +201,10 @@ public: // We keep gmod's structure in case any modules depend on it.
 	GarrysMod::Lua::ILuaObject* m_pStringPool = nullptr;
 	// But wait, theres more. In the next fields the metatables objects are saved but idk if it just has a field for each metatable or if it uses a map.
 	unsigned char m_iMetaTableIDCounter = GarrysMod::Lua::Type::COUNT;
-	GarrysMod::Lua::ILuaObject* m_pMetaTables[255] = {nullptr}; // Their index is based off their type. means m_MetaTables[Type::Entity] returns the Entity metatable.
+	// Max number of metatables
+	static inline constexpr unsigned char MAX_METATABLES = 255; // Could use this but would be overkill: std::numeric_limits<decltype(m_iMetaTableIDCounter)>::max();
+	GarrysMod::Lua::ILuaObject* m_pMetaTables[MAX_METATABLES] = {nullptr}; // Their index is based off their type. means m_MetaTables[Type::Entity] returns the Entity metatable.
+
 private: // NOT GMOD stuff
 	CThreadFastMutex m_pThreadedCallsMutex;
 	std::atomic<bool> m_bShutDownThreadedCalls = false;

--- a/source/modules/bitbuf.cpp
+++ b/source/modules/bitbuf.cpp
@@ -899,7 +899,8 @@ LUA_FUNCTION_STATIC(bitbuf_CreateReadBuffer)
 	
 	// The buffer is part of the userdata, appended after the bf_read
 	void* bufferData = (void*)((char*)pNewBF + sizeof(bf_read));
-	memcpy(bufferData, pData, iLength);
+	if (iLength > 0)
+		memcpy(bufferData, pData, MIN(iLength, (size_t)iNewLength));
 
 	pNewBF->StartReading(bufferData, iNewLength);
 
@@ -956,7 +957,8 @@ LUA_FUNCTION_STATIC(bitbuf_CreateWriteBuffer)
 	
 	// The buffer is part of the userdata, appended after the bf_write
 	void* bufferData = (void*)((char*)pNewBF + sizeof(bf_write));
-	memcpy(bufferData, pData, iDataLength);
+	if (iDataLength > 0)
+		memcpy(bufferData, pData, MIN(iDataLength, iBufferLength));
 
 	pNewBF->StartWriting(bufferData, iBufferLength);
 
@@ -986,7 +988,8 @@ LUA_FUNCTION_STATIC(bitbuf_CreateStackWriteBuffer)
 			LUA->ThrowError("Cannot stackalloc at this size!");
 
 		cData = (unsigned char*)_alloca(nSize);
-		memcpy(cData, pData, iLength);
+		if (iLength > 0)
+			memcpy(cData, pData, MIN(iLength, (size_t)nSize));
 	}
 
 	bf_write pNewBf(cData, nSize);

--- a/source/modules/crashhandler.cpp
+++ b/source/modules/crashhandler.cpp
@@ -355,7 +355,7 @@ class ScopedFileDescriptor
 {
 public:
 	ScopedFileDescriptor(int fileDescriptor) : m_nFileDescriptor(fileDescriptor) {};
-	~ScopedFileDescriptor() { if (m_nFileDescriptor < 0 && m_nFileDescriptor != STDERR_FILENO) { close(m_nFileDescriptor); } }
+	~ScopedFileDescriptor() { if (m_nFileDescriptor >= 0 && m_nFileDescriptor != STDERR_FILENO) { close(m_nFileDescriptor); } }
 	ScopedFileDescriptor(const ScopedFileDescriptor&) = delete;
 	ScopedFileDescriptor& operator=(const ScopedFileDescriptor&) = delete;
 	operator int() const { return m_nFileDescriptor; }

--- a/source/modules/filesystem.cpp
+++ b/source/modules/filesystem.cpp
@@ -2005,9 +2005,11 @@ void AsyncCallback(const FileAsyncRequest_t &request, int nBytesRead, FSAsyncSta
 	{
 		async->nBytesRead = nBytesRead;
 		async->status = err;
-		char* content = new char[nBytesRead + 1];
-		std::memcpy(static_cast<void*>(content), request.pData, nBytesRead);
-		content[nBytesRead] = '\0';
+		int nContentLength = nBytesRead > 0 && request.pData ? nBytesRead : 0;
+		char* content = new char[nContentLength + 1];
+		if (nContentLength > 0)
+			std::memcpy(static_cast<void*>(content), request.pData, nContentLength);
+		content[nContentLength] = '\0';
 		async->content = content;
 		asyncCallback.push_back(async);
 	} else {
@@ -2144,11 +2146,11 @@ LUA_FUNCTION_STATIC(filesystem_Find)
 			std::sort(files.begin(), files.end(), std::greater<std::string>());
 			std::sort(folders.begin(), folders.end(), std::greater<std::string>());
 		} else if (strcmp(sorting, "dateasc") == 0) { // sort the files ascending by date.
-			SortByDate(files, filepath, gamePath, true);
-			SortByDate(folders, filepath, gamePath, true);
+			files = SortByDate(files, filepath, gamePath, true);
+			folders = SortByDate(folders, filepath, gamePath, true);
 		} else if (strcmp(sorting, "datedesc") == 0) { // sort the files descending by date.
-			SortByDate(files, filepath, gamePath, false);
-			SortByDate(folders, filepath, gamePath, false);
+			files = SortByDate(files, filepath, gamePath, false);
+			folders = SortByDate(folders, filepath, gamePath, false);
 		} else { // Fallback to default: nameasc | sort the files ascending by name.
 			std::sort(files.begin(), files.end());
 			std::sort(folders.begin(), folders.end());

--- a/source/modules/luathreads.cpp
+++ b/source/modules/luathreads.cpp
@@ -326,6 +326,7 @@ LUA_FUNCTION_STATIC(luathreads_FindInterface)
 	for (LuaInterface* pInterface : g_pLuaInterfaces)
 	{
 		if (V_stricmp(pName, pInterface->GetName()) != 0)
+			continue;
 
 		Push_LuaInterface(LUA, pInterface);
 		return 1;

--- a/source/modules/networking.cpp
+++ b/source/modules/networking.cpp
@@ -114,6 +114,9 @@ public:
 
 	virtual int GetPropsChangedAfterTick(int iTick, int *iOutProps, int nMaxOutProps)
 	{
+		if (nMaxOutProps <= 0)
+			return 0;
+
 		// Should we remove vprof here? It could slow this entire thing down since it's called so often
 		// VPROF_BUDGET("CChangeFrameList::GetPropsChangedAfterTick", VPROF_BUDGETGROUP_OTHER_NETWORKING);
 		int nOutProps = 0;
@@ -122,7 +125,7 @@ public:
 			if (iTick >= m_LastChangeTickNum)
 				return 0;
 
-			nOutProps = m_LastChangeTicks.size();
+			nOutProps = MIN((int)m_LastChangeTicks.size(), nMaxOutProps);
 			for (int i=0; i < nOutProps; ++i)
 				iOutProps[i] = m_LastChangeTicks[i];
 
@@ -135,6 +138,8 @@ public:
 				{
 					iOutProps[nOutProps] = i;
 					++nOutProps;
+					if (nOutProps >= nMaxOutProps)
+						break;
 				}
 			}
 
@@ -632,14 +637,14 @@ struct EntityTransmitCache // Well.... Still kinda acts as a tick-based cache, t
 				Msg("    %i: %s[%i]\n", i, pPVSEntityList[i]->GetClassname(), pPVSEntityList[i]->edict()->m_EdictIndex);
 
 			Msg("Never:\n");
-			for (int i=0; i<=pNeverTransmitBits.GetNumBits(); ++i)
+			for (int i=0; i<pNeverTransmitBits.GetNumBits(); ++i)
 			{
 				if (pNeverTransmitBits.IsBitSet(i))
 					Msg("    %i\n", i);
 			}
 
 			Msg("Always:\n");
-			for (int i=0; i<=pAlwaysTransmitBits.GetNumBits(); ++i)
+			for (int i=0; i<pAlwaysTransmitBits.GetNumBits(); ++i)
 			{
 				if (pAlwaysTransmitBits.IsBitSet(i))
 					Msg("    %i\n", i);
@@ -763,7 +768,8 @@ struct EntityTransmitCache // Well.... Still kinda acts as a tick-based cache, t
 				if (i < (pArea.nCount - 1))
 					memmove(&pArea.pEntities[i], &pArea.pEntities[i + 1], (pArea.nCount - i - 1) * sizeof(CBaseEntity*));
 
-				pArea.pEntities[pArea.nCount--] = nullptr;
+				--pArea.nCount;
+				pArea.pEntities[pArea.nCount] = nullptr;
 				break;
 			}
 		}

--- a/source/modules/networking.cpp
+++ b/source/modules/networking.cpp
@@ -114,9 +114,6 @@ public:
 
 	virtual int GetPropsChangedAfterTick(int iTick, int *iOutProps, int nMaxOutProps)
 	{
-		if (nMaxOutProps <= 0)
-			return 0;
-
 		// Should we remove vprof here? It could slow this entire thing down since it's called so often
 		// VPROF_BUDGET("CChangeFrameList::GetPropsChangedAfterTick", VPROF_BUDGETGROUP_OTHER_NETWORKING);
 		int nOutProps = 0;
@@ -125,7 +122,7 @@ public:
 			if (iTick >= m_LastChangeTickNum)
 				return 0;
 
-			nOutProps = MIN((int)m_LastChangeTicks.size(), nMaxOutProps);
+			nOutProps = m_LastChangeTicks.size();
 			for (int i=0; i < nOutProps; ++i)
 				iOutProps[i] = m_LastChangeTicks[i];
 
@@ -138,8 +135,6 @@ public:
 				{
 					iOutProps[nOutProps] = i;
 					++nOutProps;
-					if (nOutProps >= nMaxOutProps)
-						break;
 				}
 			}
 

--- a/source/modules/networkthreading.cpp
+++ b/source/modules/networkthreading.cpp
@@ -295,7 +295,7 @@ static SIMPLETHREAD_RETURNVALUE NetworkThread(void* pThreadData)
 			} 
 
 			// check for connectionless packet (0xffffffff) first
-			if (packet->size > (int)sizeof(unsigned int) && LittleLong(*(unsigned int *)packet->data) == CONNECTIONLESS_HEADER)
+			if (LittleLong(*(unsigned int *)packet->data) == CONNECTIONLESS_HEADER)
 			{
 				packet->message.SeekRelative(sizeof(long)*8);	// read the -1
 				int nPacketType = IsValidConnectionlessPacket(packet, false);
@@ -308,7 +308,7 @@ static SIMPLETHREAD_RETURNVALUE NetworkThread(void* pThreadData)
 				packet->message.StartReading( packet->data, packet->size ); // Reset buffer
 				packet->message.SeekRelative(sizeof(long)*8); // Read it again
 				if (net_showudp.GetInt())
-					Msg("UDP <- %s: sz=%i OOB '%c' wire=%i\n", packet->from.ToString(), packet->size, packet->size > 4 ? packet->data[4] : '\0', packet->wiresize);
+					Msg("UDP <- %s: sz=%i OOB '%c' wire=%i\n", packet->from.ToString(), packet->size, packet->data[4], packet->wiresize);
 
 				HandleStatus pStatus = ShouldHandlePacket(packet, true);
 				if (pStatus == HandleStatus::DISCARD)

--- a/source/modules/networkthreading.cpp
+++ b/source/modules/networkthreading.cpp
@@ -295,7 +295,7 @@ static SIMPLETHREAD_RETURNVALUE NetworkThread(void* pThreadData)
 			} 
 
 			// check for connectionless packet (0xffffffff) first
-			if (LittleLong(*(unsigned int *)packet->data) == CONNECTIONLESS_HEADER)
+			if (packet->size > (int)sizeof(unsigned int) && LittleLong(*(unsigned int *)packet->data) == CONNECTIONLESS_HEADER)
 			{
 				packet->message.SeekRelative(sizeof(long)*8);	// read the -1
 				int nPacketType = IsValidConnectionlessPacket(packet, false);
@@ -308,7 +308,7 @@ static SIMPLETHREAD_RETURNVALUE NetworkThread(void* pThreadData)
 				packet->message.StartReading( packet->data, packet->size ); // Reset buffer
 				packet->message.SeekRelative(sizeof(long)*8); // Read it again
 				if (net_showudp.GetInt())
-					Msg("UDP <- %s: sz=%i OOB '%c' wire=%i\n", packet->from.ToString(), packet->size, packet->data[4], packet->wiresize);
+					Msg("UDP <- %s: sz=%i OOB '%c' wire=%i\n", packet->from.ToString(), packet->size, packet->size > 4 ? packet->data[4] : '\0', packet->wiresize);
 
 				HandleStatus pStatus = ShouldHandlePacket(packet, true);
 				if (pStatus == HandleStatus::DISCARD)

--- a/source/modules/pvs.cpp
+++ b/source/modules/pvs.cpp
@@ -725,7 +725,7 @@ LUA_FUNCTION_STATIC(pvs_AddEntityToTransmit)
 	} else if (Is_EntityList(LUA, 1)) {
 		EntityList* entList = Get_EntityList(LUA, 1, true);
 		for (CBaseEntity* ent : entList->GetEntities())
-			AddEntityToTransmit(LUA, ent, true);
+			AddEntityToTransmit(LUA, ent, force);
 #endif
 	} else {
 		CBaseEntity* ent = Util::Get_Entity(LUA, 1, true);
@@ -742,9 +742,16 @@ LUA_FUNCTION_STATIC(pvs_SetPreventTransmitBulk)
 	if (LUA->IsType(2, GarrysMod::Lua::Type::RecipientFilter))
 	{
 		CRecipientFilter* filter = (CRecipientFilter*)Get_IRecipientFilter(LUA, 2, true);
-		for (int i=0; i<gpGlobals->maxClients; ++i)
-			if (filter->GetRecipientIndex(i) != -1)
-				filterplys.push_back(UTIL_PlayerByIndex(i));
+		for (int i=0; i<filter->GetRecipientCount(); ++i)
+		{
+			int iPlayerIndex = filter->GetRecipientIndex(i);
+			if (iPlayerIndex > 0)
+			{
+				CBasePlayer* pPlayer = UTIL_PlayerByIndex(iPlayerIndex);
+				if (pPlayer)
+					filterplys.push_back(pPlayer);
+			}
+		}
 	}
 	else if (LUA->IsType(2, GarrysMod::Lua::Type::Table))
 	{

--- a/source/modules/sourcetv.cpp
+++ b/source/modules/sourcetv.cpp
@@ -357,6 +357,9 @@ LUA_FUNCTION_STATIC(sourcetv_FireEvent)
 
 LUA_FUNCTION_STATIC(sourcetv_SetCameraMan)
 {
+	if (!hltv || !hltv->IsActive())
+		return 0;
+
 	int iTarget = 0;
 	if (LUA->IsType(1, GarrysMod::Lua::Type::Number))
 		iTarget = LUA->GetNumber(1);

--- a/source/modules/stringtable.cpp
+++ b/source/modules/stringtable.cpp
@@ -838,7 +838,7 @@ static inline void UpdateCGameServerStringTables(INetworkStringTable* pTable)
 		{
 			pServer->m_pLightStyleTable = pTable;
 		}
-		else if (!Q_stricmp(LIGHT_STYLES_TABLENAME, pTable->GetTableName()) && !pServer->m_pUserInfoTable)
+		else if (!Q_stricmp(USER_INFO_TABLENAME, pTable->GetTableName()) && !pServer->m_pUserInfoTable)
 		{
 			pServer->m_pUserInfoTable = pTable;
 		}

--- a/source/modules/voicechat.cpp
+++ b/source/modules/voicechat.cpp
@@ -49,6 +49,12 @@ static thread_local SteamOpus::Opus_FrameDecoder g_pOpusDecoder;
 static uint64_t fakeSteamID = 0x0110000100000001; // STEAM_0:1:0
 // static inline void ClearDataBuffer() { memset(g_pDataBuffer, 0, g_pDefaultDecompressedSize); }
 
+static uint16_t ClampVoiceDataLength(int iLength, size_t iDataLength)
+{
+	size_t iClampedLength = iLength <= 0 ? iDataLength : MIN((size_t)iLength, iDataLength);
+	return (uint16_t)MIN(iClampedLength, (size_t)0xFFFF);
+}
+
 static IThreadPool* pVoiceThreadPool = nullptr;
 static void OnVoiceThreadsChange(IConVar* convar, const char* pOldValue, float flOldValue)
 {
@@ -495,7 +501,8 @@ LUA_JIT_WRAPPED_3(VoiceData_SetData,
 	if (!pData || !pCompressedData)
 		return;
 
-	pData->SetData(Lua::GetGCStrData(pCompressedData), (uint16_t)(iNewLength != -1 ? iNewLength : Lua::GetGCStrLength(pCompressedData)));
+	size_t iDataLength = Lua::GetGCStrLength(pCompressedData);
+	pData->SetData(Lua::GetGCStrData(pCompressedData), ClampVoiceDataLength(iNewLength, iDataLength));
 }
 
 // This is the JIT version with (userdata, string) args while the above is (userdata, string, int)
@@ -509,7 +516,8 @@ LUA_JIT_RAW_2(VoiceData_SetData_NoLength,
 	if (!pData || !pCompressedData)
 		return;
 
-	pData->SetData(Lua::GetGCStrData(pCompressedData), (uint16_t)Lua::GetGCStrLength(pCompressedData));
+	size_t iDataLength = Lua::GetGCStrLength(pCompressedData);
+	pData->SetData(Lua::GetGCStrData(pCompressedData), ClampVoiceDataLength(-1, iDataLength));
 }
 
 LUA_FUNCTION_STATIC(VoiceData_SetProximity)
@@ -551,7 +559,7 @@ struct WavAudioFile {
 
 	void WriteData(const void* pData, int nDataLength)
 	{
-		if ((currentPos + nDataLength) >= dataSize)
+		if (nDataLength < 0 || nDataLength > dataSize - currentPos)
 		{
 			//if (g_pVoiceChatModule.InDebug() == 1)
 			{
@@ -1698,14 +1706,8 @@ LUA_FUNCTION_STATIC(voicechat_CreateVoiceData)
 
 	if (pStr)
 	{
-		int iStrLength = LUA->ObjLen(2);
-		if (iLength && iLength > iStrLength)
-			iLength = iStrLength;
-
-		if (!iLength)
-			iLength = iStrLength;
-
-		pData->SetData(pStr, iLength);
+		size_t iStrLength = LUA->ObjLen(2);
+		pData->SetData(pStr, ClampVoiceDataLength(iLength, iStrLength));
 	}
 
 	Push_VoiceData(LUA, pData);

--- a/source/util.cpp
+++ b/source/util.cpp
@@ -428,7 +428,7 @@ CBaseEntity* Util::GetCBaseEntityFromEdict(const edict_t* edict)
 
 CBaseEntity* Util::GetCBaseEntityFromIndex(int nEntIndex)
 {
-	if (nEntIndex < 0 || nEntIndex > MAX_EDICTS)
+	if (nEntIndex < 0 || nEntIndex >= MAX_EDICTS)
 		return nullptr;
 
 	return Util::servergameents->EdictToBaseEntity(Util::engineserver->PEntityOfEntIndex(nEntIndex));
@@ -734,7 +734,10 @@ DLL_EXPORT void hook_Sys_Error_Internal_ignore_this_function_in_crashes_check_yo
 		}
 	}
 
-	vsnprintf(g_pCurrentSysError, sizeof(g_pCurrentSysError), error, argsList);
+	va_list argsCopy;
+	va_copy(argsCopy, argsList);
+	vsnprintf(g_pCurrentSysError, sizeof(g_pCurrentSysError), error, argsCopy);
+	va_end(argsCopy);
 	detour_Sys_Error_Internal.GetTrampoline<Symbols::Sys_Error_Internal>()(bMinidump, error, argsList);
 	memset(g_pCurrentSysError, 0, sizeof(g_pCurrentSysError));
 }


### PR DESCRIPTION
## Summary
- Fix LuaJIT checkhook return handling and GMod userdata direct field offsets.
- Harden runtime guard paths for bounds checks, va_list reuse, short UDP packets, async read failures, bit buffer copies, voice data lengths, PVS recipient filters, and SourceTV access.
- Fix stringtable userinfo binding plus broken stringtable test syntax and case-sensitive module test gating.

## Validation
- git diff --check
- Bundled LuaJIT syntax load for changed GLua test and helper files

## Notes
Full local build was not run because this checkout is missing garrysmod_common and the local compiler toolchain.