### PR TITLE
hk_physics: Backport upstream regression fix for local constraint system

### DIFF
--- a/source/ivp/havana/havok/hk_physics/constraint/local_constraint_system/local_constraint_system.cpp
+++ b/source/ivp/havana/havok/hk_physics/constraint/local_constraint_system/local_constraint_system.cpp
@@ -278,7 +278,7 @@ void hk_Local_Constraint_System::apply_effector_PSI(hk_PSI_Info& pi, hk_Array<hk
 	for (int i = 0; i < m_n_iterations; i++)
 	{
 		// do the steps
-		for (int x = 0; x < 2 && hk_Math::almost_zero(taus[x]); x++)
+		for (int x = 0; x < 2 && !hk_Math::almost_zero(taus[x]); x++)
 		{
 			for (int ii = m_constraints.length() - 1; ii >= 0; ii--) {
 				m_constraints.element_at(ii)->step_constraint(pi, vmq_buffers[ii], taus[x], damps[x]);


### PR DESCRIPTION
# Description

It was accidentally broken in upstream ivp repo (see https://github.com/Source-Authors/source-physics/commit/340ce9c78a9b1162fc309752cfc13eeb23597144#diff-2a3743577e228f80d52d51aef0369fc4b85dc347780decfc5f9743d6c1f6d42fR282).

`taus[x] != 0` was mistakenly inversed to `hk_Math::almost_equal(taus[x], 0.0f)`.
Restoring back.