### PR TITLE
lua/scripts: fix FFI Angle:Up returning the forward vector

### DIFF
--- a/gluatests/lua/tests/modules/luajit/AngleUp.lua
+++ b/gluatests/lua/tests/modules/luajit/AngleUp.lua
@@ -1,0 +1,60 @@
+local angleUp = Angle().Up
+local nativeUp = FindMetaTable("Angle").Up
+local epsilon = 0.00001
+local components = { -360, -180, -90, -30, 0, 30, 90, 180, 360 }
+
+local function expectVector(actual, expected)
+    expect( isvector(actual) ).to.beTrue()
+    expect( math.abs(actual.x - expected.x) < epsilon ).to.beTrue()
+    expect( math.abs(actual.y - expected.y) < epsilon ).to.beTrue()
+    expect( math.abs(actual.z - expected.z) < epsilon ).to.beTrue()
+end
+
+return {
+    groupName = "Angle:Up",
+    cases = {
+        {
+            name = "Returns the expected up axis for cardinal rotations",
+            func = function()
+                expectVector(angleUp(Angle(0, 0, 0)), Vector(0, 0, 1))
+                expectVector(angleUp(Angle(0, 90, 0)), Vector(0, 0, 1))
+                expectVector(angleUp(Angle(90, 0, 0)), Vector(1, 0, 0))
+                expectVector(angleUp(Angle(0, 0, 90)), Vector(0, -1, 0))
+                expectVector(angleUp(Angle(0, 0, -90)), Vector(0, 1, 0))
+                expectVector(angleUp(Angle(0, 0, 180)), Vector(0, 0, -1))
+            end
+        },
+        {
+            name = "Matches the native up axis across pitch, yaw and roll",
+            func = function()
+                for _, pitch in ipairs(components) do
+                    for _, yaw in ipairs(components) do
+                        for _, roll in ipairs(components) do
+                            local angle = Angle(pitch, yaw, roll)
+                            expectVector(angleUp(angle), nativeUp(angle))
+                        end
+                    end
+                end
+            end
+        },
+        {
+            name = "Returns a unit vector perpendicular to forward and right without changing the angle",
+            func = function()
+                for _, pitch in ipairs(components) do
+                    for _, yaw in ipairs(components) do
+                        for _, roll in ipairs(components) do
+                            local angle = Angle(pitch, yaw, roll)
+                            local up = angleUp(angle)
+                            expect( math.abs(up:LengthSqr() - 1) < epsilon ).to.beTrue()
+                            expect( math.abs(up:Dot(angle:Forward())) < epsilon ).to.beTrue()
+                            expect( math.abs(up:Dot(angle:Right())) < epsilon ).to.beTrue()
+                            expect( angle.p ).to.equal(pitch)
+                            expect( angle.y ).to.equal(yaw)
+                            expect( angle.r ).to.equal(roll)
+                        end
+                    end
+                end
+            end
+        },
+    }
+}

--- a/source/lua/scripts/AngleFFI.lua
+++ b/source/lua/scripts/AngleFFI.lua
@@ -286,9 +286,9 @@ function methods:Up()
     local cr = math.cos(rr)
     local sr = math.sin(rr)
 
-    local x = cp * cy
-    local y = cp * sy
-    local z = -sp
+    local x = cr * sp * cy + sr * sy
+    local y = cr * sp * sy - sr * cy
+    local z = cr * cp
 
     return Vector(x, y, z)
 end


### PR DESCRIPTION
# Description

With HolyLib's FFI angles enabled, `Angle:Up()` returns the forward vector. For example, `Angle(0, 0, 0):Up()` returns `Vector(1, 0, 0)` instead of `Vector(0, 0, 1)`. The current implementation calculates roll sine/cosine but then uses the same three component expressions as `Forward()`.

Use the pitch/yaw/roll up-axis formula, retaining the existing Lua/FFI implementation and return type. This restores the [documented Angle:Up behavior](https://wiki.facepunch.com/gmod/Angle:Up). In JMod this bug collapsed directional fragment spread into effectively one line because the fragments were rotated around their forward axis.

Add GLuaTest coverage for six cardinal rotations, a 729-angle comparison against the native `FindMetaTable("Angle").Up`, and unit-length/perpendicularity/input-preservation checks.

## Reproduction

Run on a server with FFI angles enabled:

```lua
local a = Angle(0, 0, 0)
print(a:Up())                         -- actual: 1 0 0; expected: 0 0 1
print(a:Forward())                    -- 1 0 0
print(FindMetaTable("Angle").Up(a))    -- 0 0 1
```

The same mismatch is present for nonzero pitch, yaw and roll. It exists in upstream `main` at `b4bbc5c5ed7cdbc6903e585b705a73e2ad678ed5`.

## Validation

- Reproduced on a Linux x86-64 dedicated server, GMod `2026.08.04`, using HolyLib's custom LuaJIT.
- All three regression cases fail against the existing FFI method and pass against the candidate method.
- Another 2,048 fractional, negative and multi-turn angle combinations matched the native method within `1e-5`; maximum component difference was `7.7486e-7`.
- Full candidate Lua file compiles; `git diff --check` passes.

Runtime validation compiled the exact candidate `Up` function in isolation and bound the regression suite's local method reference to it, using real FFI angles/vectors and the native method as the oracle. It did not replace live global methods or rebuild/restart HolyLib. Full packaged GLuaTest/CI and other platform coverage remain pending.
